### PR TITLE
Raise upper bound on -web dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,10 +16,10 @@
     "output"
   ],
   "dependencies": {
-    "purescript-web-html": "^1.0.0",
+    "purescript-web-html": ">=1.0.0 <3.0.0",
     "purescript-aff": "^5.0.0",
     "purescript-arraybuffer-types": "^2.0.0",
-    "purescript-web-file": "^1.0.0"
+    "purescript-web-file": ">=1.0.0 <3.0.0"
   },
   "devDependencies": {
     "purescript-console": "^4.1.0"


### PR DESCRIPTION
As-is, this isn't necessarily a breaking change. I can do that if you'd prefer though.

The breaking change in `-web` was to make `defaultPrevented` use `Effect`.